### PR TITLE
README banner standardization (badges + sections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # clawbot-home-assistant
+
+<!-- plures-readme-banner -->
+[![CI](https://img.shields.io/badge/CI-not_configured-lightgrey.svg)](https://github.com/plures/clawbot-home-assistant/actions)\n[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 Clawbot integration for Home Assistant (dogfooding + automations)
+
+---
+
+<!-- plures-readme-standard-sections -->
+## Overview\n\n## Install\n\n## Development\n\n## Contributing\n\n## License


### PR DESCRIPTION
This PR applies the Plures README at-a-glance standard:\n\n- Adds a top-of-README banner block (CI badge where available; placeholder where not yet configured)\n- Adds standard section headers to make repos consistent\n\nLocal-first change; non-destructive.\n\nFollow-ups:\n- For repos with placeholder CI badge, add a minimal CI workflow so the badge becomes meaningful.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or functional code is modified.
> 
> **Overview**
> Updates `README.md` to follow a standard format by adding a top banner block (CI placeholder badge + MIT license badge) and inserting standard sections (`Overview`, `Install`, `Development`, `Contributing`, `License`) separated by a horizontal rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 054ea3cc7ef6b924c6ccb3eecf8c9bb6494c6345. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->